### PR TITLE
Fix component constructor arguments

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -35,6 +35,6 @@ CreateCache.prototype.render = function (Component) {
 
 // Because you can't call `new` and `.apply()` at the same time. This is a mad
 // hack, but hey it works so we gonna go for it. Whoop.
-function newCall (Cls) {
-  return new (Cls.bind.apply(Cls, arguments)) // eslint-disable-line
+function newCall (Cls, args) {
+  return new (Cls.bind.apply(Cls, [Cls].concat(args))) // eslint-disable-line
 }


### PR DESCRIPTION
The mad hack for spreading arguments to the component constructor would just forward the array of arguments, not spread them. Prob nanocomponent should have caught it by asserting that `name` is a string, which it doesn't. Anyhow, this fixes constructor arguments.