### PR TITLE
Fix emit being bound to self

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = store
 function store () {
   return function (state, emitter, app) {
     var setRoute = app.route.bind(app)
-    var cache = createCache(state, emitter.emit)
+    var cache = createCache(state, emitter.emit.bind(emitter))
 
     app.route = function (route, callback) {
       setRoute(route, function (state, emit) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -7,7 +7,7 @@ function CreateCache (state, emit) {
   assert.equal(typeof state, 'object', 'CreateCache: state should be type object')
   assert.equal(typeof emit, 'function', 'CreateCache: state should be type function')
 
-  this.emit = emit.bind(emit)
+  this.emit = emit
   this.state = state
   this.cache = {}
 }


### PR DESCRIPTION
This fixes `emit` being bound to itself as opposed to the bus instance.