### PR TITLE
update api

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ var Component = require('nanocomponent')
 var html = require('choo/html')
 
 module.exports = class Article extends Component {
-  static identity (article) {
-    return `article-${article.id}`
+  constructor (name, state, emit) {
+    super(name)
+    this.state = state
+    this.emit = emit
   }
 
   createElement (article) {
@@ -43,13 +45,15 @@ var Article = require('./components/article')
 var Header = require('./components/header')
 var Footer = require('./components/footer')
 
-module.exports = function (state, emit, render) {
+module.exports = function (state, emit) {
   return html`
-    <body
-      ${render(Header)}
-      ${state.articles.map(article => render(Article, article))}
-      ${render(Footer)}
-    </body
+    <body>
+      ${state.cache(Header, 'header').render()}
+      ${state.articles.map(article => {
+        return state.cache(Article, article.id).render(article)
+      })}
+      ${state.cache(Footer, 'footer').render()}
+    </body>
   `
 }
 ```

--- a/example/component.js
+++ b/example/component.js
@@ -2,7 +2,7 @@ var Component = require('nanocomponent')
 var html = require('choo/html')
 
 module.exports = class Something extends Component {
-  static identity (name) {
+  static id (name) {
     return `something-${name}`
   }
 

--- a/example/component.js
+++ b/example/component.js
@@ -2,10 +2,6 @@ var Component = require('nanocomponent')
 var html = require('choo/html')
 
 module.exports = class Something extends Component {
-  static id (name) {
-    return `something-${name}`
-  }
-
   createElement (name) {
     return html`
       <h1>${name}</h1>

--- a/example/other.js
+++ b/example/other.js
@@ -2,13 +2,13 @@ var html = require('choo/html')
 
 var Component = require('./component')
 
-module.exports = function (state, emit, render) {
+module.exports = function (state, emit) {
   return html`
     <body>
       <h1>Sup planet</h1>
-      ${render(Component, 'other')}
-      ${render(Component, 'header')}
-      ${render(Component, 'footer')}
+        ${state.cache(Component, 'other').render()}
+        ${state.cache(Component, 'header').render()}
+        ${state.cache(Component, 'footer').render()}
       <a href="/">home</a>
     </body>
   `

--- a/example/view.js
+++ b/example/view.js
@@ -2,12 +2,12 @@ var html = require('choo/html')
 
 var Component = require('./component')
 
-module.exports = function (state, emit, render) {
+module.exports = function (state, emit) {
   return html`
     <body>
       <h1>Sup planet</h1>
-      ${render(Component, 'header')}
-      ${render(Component, 'footer')}
+        ${state.cache(Component, 'header').render()}
+        ${state.cache(Component, 'footer').render()}
       <a href="/other">other</a>
     </body>
   `

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var Cache = require('./lib/cache')
-var onIdle = require('on-idle')
 var assert = require('assert')
 
 module.exports = store
@@ -7,18 +6,6 @@ module.exports = store
 function store () {
   return function (state, emitter, app) {
     var cache = new Cache(state, emitter.emit.bind(emitter))
-
-    // TODO: replace with LRU cache.
-    emitter.on(state.events.RENDER, function () {
-      onIdle(function cleanup () {
-        var keys = Object.keys(cache.cache)
-        for (var id, i = 0, len = keys.length; i < len; i++) {
-          id = keys[i]
-          if (!cache.cache[id].element) delete cache.cache[id]
-        }
-      })
-    })
-
     state.cache = Render
 
     function Render (Component, id) {

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ var assert = require('assert')
 
 module.exports = store
 
-function store () {
+function store (lru) {
   return function (state, emitter, app) {
-    var cache = new Cache(state, emitter.emit.bind(emitter))
+    var cache = new Cache(state, emitter.emit.bind(emitter), lru)
     state.cache = Render
 
     function Render (Component, id) {

--- a/index.js
+++ b/index.js
@@ -29,5 +29,11 @@ function store () {
       }
       return cache.render.apply(cache, args)
     }
+
+    // When the state gets stringified, make sure `state.cache` isn't
+    // stringified too.
+    Render.toJson = function () {
+      return null
+    }
   }
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,40 +1,38 @@
 var assert = require('assert')
 
-module.exports = CreateCache
+module.exports = ChooComponentCache
 
-function CreateCache (state, emit) {
-  if (!(this instanceof CreateCache)) return new CreateCache(state, emit)
-  assert.equal(typeof state, 'object', 'CreateCache: state should be type object')
-  assert.equal(typeof emit, 'function', 'CreateCache: state should be type function')
+function ChooComponentCache (state, emit) {
+  assert.ok(this instanceof ChooComponentCache, 'ChooComponentCache should be created with `new`')
+  assert.equal(typeof state, 'object', 'ChooComponentCache: state should be type object')
+  assert.equal(typeof emit, 'function', 'ChooComponentCache: state should be type function')
 
-  this.emit = emit
   this.state = state
+  this.emit = emit
   this.cache = {}
 }
 
-CreateCache.prototype.render = function (Component) {
-  assert.equal(typeof Component, 'function', 'CreateCache.render: Component should be type function')
-  var args = []
-  for (var i = 1, len = arguments.length; i < len; i++) {
-    args.push(arguments[i])
-  }
-
-  assert.equal(typeof Component.identity, 'function', 'CreateCache.render: Component.identity should be type function')
-  var id = Component.identity(args)
-  assert.equal(typeof id, 'string', 'CreateCache.render: Component.identity should return type string')
+// Get & create component instances.
+ChooComponentCache.prototype.render = function (Component, id) {
+  assert.equal(typeof Component, 'function', 'ChooComponentCache.render: Component should be type function')
+  assert.ok(typeof id === 'string' || typeof id === 'number', 'ChooComponentCache.render: id should be type string or type number')
 
   var el = this.cache[id]
   if (!el) {
-    var ext = args.slice(0)
-    ext.unshift(id, this.state, this.emit)
-    el = newCall(Component, ext)
+    var args = []
+    for (var i = 0, len = arguments.length; i < len; i++) {
+      args.push(arguments[i])
+    }
+    args.unshift(Component, id, this.state, this.emit)
+    el = newCall.apply(newCall, args)
     this.cache[id] = el
   }
-  return el.render.apply(el, args)
+
+  return el
 }
 
 // Because you can't call `new` and `.apply()` at the same time. This is a mad
 // hack, but hey it works so we gonna go for it. Whoop.
-function newCall (Cls, args) {
-  return new (Cls.bind.apply(Cls, [Cls].concat(args))) // eslint-disable-line
+function newCall (Cls) {
+  return new (Cls.bind.apply(Cls, arguments)) // eslint-disable-line
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,15 +1,17 @@
 var assert = require('assert')
+var LRU = require('nanolru')
 
 module.exports = ChooComponentCache
 
-function ChooComponentCache (state, emit) {
+function ChooComponentCache (state, emit, lru) {
   assert.ok(this instanceof ChooComponentCache, 'ChooComponentCache should be created with `new`')
+
   assert.equal(typeof state, 'object', 'ChooComponentCache: state should be type object')
   assert.equal(typeof emit, 'function', 'ChooComponentCache: state should be type function')
 
+  this.cache = lru || new LRU(100)
   this.state = state
   this.emit = emit
-  this.cache = {}
 }
 
 // Get & create component instances.
@@ -17,7 +19,7 @@ ChooComponentCache.prototype.render = function (Component, id) {
   assert.equal(typeof Component, 'function', 'ChooComponentCache.render: Component should be type function')
   assert.ok(typeof id === 'string' || typeof id === 'number', 'ChooComponentCache.render: id should be type string or type number')
 
-  var el = this.cache[id]
+  var el = this.cache.get(id)
   if (!el) {
     var args = []
     for (var i = 0, len = arguments.length; i < len; i++) {
@@ -25,7 +27,7 @@ ChooComponentCache.prototype.render = function (Component, id) {
     }
     args.unshift(Component, id, this.state, this.emit)
     el = newCall.apply(newCall, args)
-    this.cache[id] = el
+    this.cache.set(id, el)
   }
 
   return el

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "test": "standard"
   },
   "dependencies": {
-    "nanolru": "^1.0.0",
-    "on-idle": "^3.1.4"
+    "nanolru": "^1.0.0"
   },
   "devDependencies": {
     "bankai": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "standard"
   },
   "dependencies": {
+    "nanolru": "^1.0.0",
     "on-idle": "^3.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
- use LRU cache
- add a `.get()` API
- no longer implicit `.render()` calls
- no longer require `.id` static method
- remove third`render` argument in view functions, and replace with `state.cache` instead