### PR TITLE
Fix toJSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function store (lru) {
 
     // When the state gets stringified, make sure `state.cache` isn't
     // stringified too.
-    Render.toJson = function () {
+    Render.toJSON = function () {
       return null
     }
   }


### PR DESCRIPTION
Fix typo in [`toJSON`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior) method name.